### PR TITLE
Use local convert_to_target 

### DIFF
--- a/qiskit_ibm_runtime/fake_provider/fake_backend.py
+++ b/qiskit_ibm_runtime/fake_provider/fake_backend.py
@@ -31,7 +31,6 @@ from qiskit.exceptions import QiskitError
 from qiskit.utils import optionals as _optionals
 from qiskit.transpiler import Target
 from qiskit.providers import Options
-from qiskit.providers.backend_compat import convert_to_target
 from qiskit.providers.fake_provider.utils.json_decoder import (
     decode_backend_configuration,
     decode_backend_properties,
@@ -39,6 +38,8 @@ from qiskit.providers.fake_provider.utils.json_decoder import (
 )
 
 from qiskit.providers.basic_provider import BasicSimulator
+
+from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
 
 
 class _Credentials:
@@ -179,7 +180,7 @@ class FakeBackendV2(BackendV2):
                 defaults = PulseDefaults.from_dict(self._defs_dict)  # type: ignore
 
             self._target = convert_to_target(
-                conf, props, defaults, add_delay=True, filter_faulty=True
+                conf, props, defaults
             )
 
         return self._target


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After the `convert_to_target` function fixes in [PR](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1600)

### Details and comments
Fixes #1570

- [X] Use the `convert_to_target` local function

### Test Evidence
Using `from qiskit.providers.backend_compat import convert_to_target`

     ` fake_sherbrooke ['rz', 'delay', 'sx', 'measure', 'if_else', 'ecr', 'x']   # operation_names`

Using `from qiskit_ibm_runtime.utils.backend_converter import convert_to_target`

      `fake_sherbrooke ['delay', 'reset', 'ecr', 'if_else', 'rz', 'x', 'measure', 'sx'] # operation_names`